### PR TITLE
Optimize `isolate_roots`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArbExtras"
 uuid = "c87f5d39-a852-4149-8a88-e3a13a25afc6"
 authors = ["Joel Dahne <joel@dahne.eu>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Arblib = "fb37089c-8514-4489-9461-98f9c8763369"

--- a/src/isolate_roots.jl
+++ b/src/isolate_roots.jl
@@ -37,6 +37,9 @@ function _check_root_interval(
     buffer1::Arb = zero(Arb),
     buffer2::Arb = zero(Arb), # Not used
 )
+    # If signs of endpoints could not be determined return immediately
+    iszero(fa_sign) || iszero(fb_sign) && return true, false
+
     # buffer1 = Arb((a, b))
     Arblib.set_interval!(buffer1, a, b)
 
@@ -64,6 +67,9 @@ function _check_root_interval(
     buffer1::Arb = zero(Arb),
     buffer2::Arb = zero(Arb),
 )
+    # If signs of endpoints could not be determined return immediately
+    iszero(fa_sign) || iszero(fb_sign) && return true, false
+
     # buffer1 = Arb((a, b))
     Arblib.set_interval!(buffer1, a, b)
 

--- a/test/isolate_roots.jl
+++ b/test/isolate_roots.jl
@@ -29,6 +29,11 @@
             Arf(1.6),
         ) == (false, false)
 
+        # Zero at endpoint
+        @test ArbExtras._check_root_interval(sin, Arf(0), Arf(1)) == (true, false)
+        @test ArbExtras._check_root_interval(sin, Arf(-1), Arf(0)) == (true, false)
+        @test ArbExtras._check_root_interval(cospi, Arf(0), Arf(1 // 2)) == (true, false)
+
         # Multiple simple zeros in the interval
         @test ArbExtras._check_root_interval(sin, Arf(-1), Arf(4)) == (true, false)
         @test ArbExtras._check_root_interval(sin, Arf(-4), Arf(1)) == (true, false)
@@ -88,6 +93,14 @@
             Arf(-1),
             Arf(1),
         ) == (false, false)
+
+        # Zero at endpoint
+        @test ArbExtras._check_root_interval(ArbPoly([0, 1]), Arf(0), Arf(1)) ==
+              (true, false)
+        @test ArbExtras._check_root_interval(ArbPoly([0, 1]), Arf(-1), Arf(0)) ==
+              (true, false)
+        @test ArbExtras._check_root_interval(ArbPoly([-1, 0, 1]), Arf(0), Arf(1)) ==
+              (true, false)
 
         # Multiple simple zeros in the interval
         @test ArbExtras._check_root_interval(


### PR DESCRIPTION
Avoid computing signs on endpoints multiple times and short circuit if sign cannot be determined on endpoint.