### PR TITLE
Add detailed logging to `extrema_enclosure` and related methods

### DIFF
--- a/src/ArbExtras.jl
+++ b/src/ArbExtras.jl
@@ -4,6 +4,7 @@ using Arblib, SpecialFunctions
 
 include("temporary.jl")
 include("utilities.jl")
+include("BisectionLogging.jl")
 
 include("isolate_roots.jl")
 include("refine_root.jl")

--- a/src/BisectionLogging.jl
+++ b/src/BisectionLogging.jl
@@ -1,0 +1,54 @@
+"""
+    BisectionLogging{T}
+
+Data structure for logging information in an algorithm applying an
+adaptive bisection approach.
+
+It consists of two vectors. One vector with subintervals represented
+by pairs of `Arf` values and one vector with data of type `T`
+associated to each subinterval. If `logger::BisectionLogging` is the
+logger, then the subintervals are given by `logger.intervals` and the
+associated data by `logger.data`.
+
+The subintervals are disjoint, sorted and cover the entire interval on
+which the bisection was applied.
+
+The data associated to each interval depends on the method from which
+this is returned. For e.g. [`minimum_enclosure`](@ref) and
+[`maximum_enclosure`](@ref) the data is of type `Arb` and represents
+an enclosure of the minimum, respectively maximum, on each subinterval.
+
+# Extended help
+
+## Implementing a method using `BisectionLogging`
+
+It is the responsibility of the method logging the data to ensure that
+the above specifications are satisfied. During the logging process it
+is usually convenient to keep the subintervals unsorted and only sort
+them at the end. Data can then be added to the `logger` with e.g.
+
+```
+push!(logger.intervals, intervals[i])
+push!(logger.data, values[i])
+```
+
+Before the logger is returned, it should be sorted so that the
+subintervals are ordered. This can be done with
+
+```
+sort_logger!(logger)
+```
+"""
+struct BisectionLogging{T}
+    intervals::Vector{NTuple{2,Arf}}
+    data::Vector{T}
+end
+
+BisectionLogging{T}() where {T} = BisectionLogging(NTuple{2,Arf}[], T[])
+
+function sort_logger!(logger::BisectionLogging)
+    perm = sortperm(logger.intervals, by = first)
+    permute!(logger.intervals, perm)
+    permute!(logger.data, perm)
+    return logger
+end

--- a/src/extrema_enclosure.jl
+++ b/src/extrema_enclosure.jl
@@ -2,15 +2,14 @@
     _current_lower_upper_bound(minormax, low, upp, values_low, values_upp, values)
 
 Returns a lower and upper bound of the extremum given that `low` and
-`upp` and lower and upper bounds of the extremum and so are all values
-in `values_low` and `Values_upp` respectively. It determines
+`upp` are lower and upper bounds of the extremum and so are all values
+in `values_low` and `values_upp` respectively. It determines
 **either** the minimum or the maximum depending on if `minormax = min`
 or `minormax = max`.
 
 This is mainly an internal function which implements behaviour which
 is common for [`extrema_enclosure`](@ref), [`minimum_enclosure`](@ref)
 and [`maximum_enclosure`](@ref).
-
 """
 function _current_lower_upper_bound(
     minormax::Union{typeof(min),typeof(max)},
@@ -53,7 +52,7 @@ function _current_lower_upper_bound(
 end
 
 """
-    extrema_enclosure(f, a::Arf, b::Arf; degree, atol, rtol, lbound_tol, ubound_tol, abs_value, log_bisection, point_value_min, point_value_max, depth_start, maxevals, depth, threaded, verbose)
+    extrema_enclosure(f, a::Arf, b::Arf; degree, atol, rtol, lbound_tol, ubound_tol, abs_value, log_bisection, point_value_min, point_value_max, depth_start, maxevals, depth, threaded, verbose, logging)
 
 Compute both the minimum and maximum of the function `f` on the
 interval `[a, b]` and return them as a 2-tuple.
@@ -84,7 +83,7 @@ value, then you don't need to bisect if the current enclosure is good
 enough. See also [`bounded_by`](@ref) if you only need to prove that
 `f` is bounded by some value.
 
-If `abs_value = true` the compute the extrema of `abs(f(x))` on the
+If `abs_value = true` then compute the extrema of `abs(f(x))` on the
 interval `[a, b]`. For the computation of the maximum this is mostly
 the same, only difference is that we have to take the absolute value
 of the evaluations. For the minimum we have to take into account that
@@ -94,14 +93,14 @@ If `log_bisection = true` then the intervals are bisected in a
 logarithmic scale, see [`bisect_interval`](@ref) for details.
 
 The arguments `point_value_min` and `point_value_max` can optionally
-be set to a a priori upper or lower bounds of the min and max
+be set to an a priori upper or lower bounds of the min and max
 respectively. Typically this is computed by evaluating `f` on some
 (possibly well chosen) points before calling this method and taking
 the minimum and maximum of the evaluations respectively. This can
 allow the method to quicker discard subintervals where the extrema
 could not possibly be located.
 
-The argument `depth_start` bisect the interval using
+The argument `depth_start` bisects the interval using
 [`bisect_interval_recursive`](@ref) before starting to compute the
 extrema. This can be useful if it is known beforehand that a certain
 number of bisections will be necessary before the enclosures get good
@@ -118,10 +117,18 @@ using [`Threads.@threads`](@ref).
 
 If `verbose = true` then output information about the process.
 
+The `logging` argument can be set to make the function return extra
+details about the computations. It should be set to either
+`Val(false)` (the default) for no logging, or `Val(true)` for logging
+enabled. If `logging = Val(true)` then the function returns three
+values, instead of the usual two. The last argument is a
+[`BisectionLogging`](@ref) struct, containing information about how
+the interval was bisected and the enclosures of the minimum and
+maximum on each subinterval.
+
 TODO: Currently this always computes both minimum and maximum on all
 subintervals. Change it so that it takes into account if the
 minimum/maximum could be located in the subinterval or not.
-
 """
 function extrema_enclosure(
     f,
@@ -141,14 +148,27 @@ function extrema_enclosure(
     depth::Integer = 20,
     threaded = false,
     verbose = false,
+    logging::Union{Val{false},Val{true}} = Val{false}(),
 )
     check_interval(a, b)
+
+    logger = if logging isa Val{true}
+        BisectionLogging{NTuple{2,Arb}}()
+    else
+        nothing
+    end
 
     if a == b
         res = f(Arb(a))
         abs_value && Arblib.abs!(res, res)
         abs_value && Arblib.nonnegative_part!(res, res)
-        return res, res
+        if logging isa Val{true}
+            push!(logger.intervals, (a, b))
+            push!(logger.data, (res, res))
+            return res, res, logger
+        else
+            return res, res
+        end
     end
 
     lbound_tol = convert(Arb, lbound_tol)
@@ -275,10 +295,18 @@ function extrema_enclosure(
                 end
             end
         end
-        intervals = bisect_intervals(intervals, to_split, log_midpoint = log_bisection)
+
+        if logging isa Val{true}
+            for i in eachindex(intervals)
+                if !to_split[i]
+                    push!(logger.intervals, intervals[i])
+                    push!(logger.data, (values_min[i], values_max[i]))
+                end
+            end
+        end
 
         verbose && @info "iteration: $(lpad(iterations, 2)), " *
-              "remaining intervals: $(lpad(length(intervals) ÷ 2, 3)), " *
+              "remaining intervals: $(lpad(sum(to_split) ÷ 2, 3)), " *
               "min: $(format_interval(min_current_low, min_current_upp)) " *
               "max: $(format_interval(max_current_low, max_current_upp))"
 
@@ -290,7 +318,7 @@ function extrema_enclosure(
                       "max: $(lpad(non_finite_max, 3))"
         end
 
-        isempty(intervals) && break
+        any(to_split) || break
 
         # Check if we have done the maximum number of function
         # evaluations or reached the maximum depth
@@ -300,10 +328,23 @@ function extrema_enclosure(
                     @info "reached maximum number of evaluations $evals >= $maxevals"
                 iterations >= depth - depth_start && @info "reached maximum depth $depth"
             end
+
+            if logging isa Val{true}
+                # Log intervals that were not included above
+                for i in eachindex(intervals)
+                    if to_split[i]
+                        push!(logger.intervals, intervals[i])
+                        push!(logger.data, (values_min[i], values_max[i]))
+                    end
+                end
+            end
+
             min_low, min_upp = min_current_low, min_current_upp
             max_low, max_upp = max_current_low, max_current_upp
             break
         end
+
+        intervals = bisect_intervals(intervals, to_split, log_midpoint = log_bisection)
     end
 
     res_min = Arb((min_low, min_upp))
@@ -312,16 +353,22 @@ function extrema_enclosure(
         Arblib.nonnegative_part!(res_min, res_min)
         Arblib.nonnegative_part!(res_max, res_max)
     end
-    return res_min, res_max
+    if logging isa Val{true}
+        sort_logger!(logger)
+        return res_min, res_max, logger
+    else
+        return res_min, res_max
+    end
 end
 
 """
-    minimum_enclosure(f, a::Arf, b::Arf; degree, atol, rtol, lbound_tol, abs_value, log_bisection, point_value_min, depth_start, maxevals, depth, threaded, verbose)
+    minimum_enclosure(f, a::Arf, b::Arf; degree, atol, rtol, lbound_tol, abs_value, log_bisection, point_value_min, depth_start, maxevals, depth, threaded, verbose, logging)
 
 Compute the minimum of the function `f` on the interval `[a, b]`.
 
-Takes the same arguments as [`extrema_polynomial`](@ref). The
-algorithm is also the same except that it only looks for the minimum.
+Takes the same arguments as [`extrema_enclosure`](@ref), except for
+`ubound_tol` and `point_value_max`. The algorithm is also the same
+except that it only looks for the minimum.
 """
 function minimum_enclosure(
     f,
@@ -339,14 +386,27 @@ function minimum_enclosure(
     depth::Integer = 20,
     threaded = false,
     verbose = false,
+    logging::Union{Val{false},Val{true}} = Val{false}(),
 )
     check_interval(a, b)
+
+    logger = if logging isa Val{true}
+        BisectionLogging{Arb}()
+    else
+        nothing
+    end
 
     if a == b
         res = f(Arb(a))
         abs_value && Arblib.abs!(res, res)
         abs_value && Arblib.nonnegative_part!(res, res)
-        return res
+        if logging isa Val{true}
+            push!(logger.intervals, (a, b))
+            push!(logger.data, res)
+            return res, logger
+        else
+            return res
+        end
     end
 
     lbound_tol = convert(Arb, lbound_tol)
@@ -444,10 +504,18 @@ function minimum_enclosure(
                 end
             end
         end
-        intervals = bisect_intervals(intervals, to_split, log_midpoint = log_bisection)
+
+        if logging isa Val{true}
+            for i in eachindex(intervals)
+                if !to_split[i]
+                    push!(logger.intervals, intervals[i])
+                    push!(logger.data, values[i])
+                end
+            end
+        end
 
         verbose && @info "iteration: $(lpad(iterations, 2)), " *
-              "remaining intervals: $(lpad(length(intervals) ÷ 2, 3)), " *
+              "remaining intervals: $(lpad(sum(to_split) ÷ 2, 3)), " *
               "minimum: $(format_interval(min_current_low, min_current_upp))"
 
         if verbose
@@ -455,7 +523,7 @@ function minimum_enclosure(
             non_finite > 0 && @info "non-finite intervals: $non_finite"
         end
 
-        isempty(intervals) && break
+        any(to_split) || break
 
         # Check if we have done the maximum number of function
         # evaluations or reached the maximum depth
@@ -465,23 +533,42 @@ function minimum_enclosure(
                     @info "reached maximum number of evaluations $evals >= $maxevals"
                 iterations >= depth - depth_start && @info "reached maximum depth $depth"
             end
+
+            if logging isa Val{true}
+                # Log intervals that were not included above
+                for i in eachindex(intervals)
+                    if to_split[i]
+                        push!(logger.intervals, intervals[i])
+                        push!(logger.data, values[i])
+                    end
+                end
+            end
+
             min_low, min_upp = min_current_low, min_current_upp
             break
         end
+
+        intervals = bisect_intervals(intervals, to_split, log_midpoint = log_bisection)
     end
 
     res = Arb((min_low, min_upp))
     abs_value && Arblib.nonnegative_part!(res, res)
-    return res
+    if logging isa Val{true}
+        sort_logger!(logger)
+        return res, logger
+    else
+        return res
+    end
 end
 
 """
-    maximum_enclosure(f, a::Arf, b::Arf; degree, atol, rtol, ubound_tol, abs_value, log_bisection, point_value_max, depth_start, maxevals, depth, threaded, verbose)
+    maximum_enclosure(f, a::Arf, b::Arf; degree, atol, rtol, ubound_tol, abs_value, log_bisection, point_value_max, depth_start, maxevals, depth, threaded, verbose, logging)
 
 Compute the maximum of the function `f` on the interval `[a, b]`.
 
-Takes the same arguments as [`extrema_polynomial`](@ref). The
-algorithm is also the same except that it only looks for the maximum.
+Takes the same arguments as [`extrema_enclosure`](@ref), except for
+`lbound_tol` and `point_value_min`. The algorithm is also the same
+except that it only looks for the maximum.
 """
 function maximum_enclosure(
     f,
@@ -499,13 +586,27 @@ function maximum_enclosure(
     depth::Integer = 20,
     threaded = false,
     verbose = false,
+    logging::Union{Val{false},Val{true}} = Val{false}(),
 )
     check_interval(a, b)
+
+    logger = if logging isa Val{true}
+        BisectionLogging{Arb}()
+    else
+        nothing
+    end
 
     if a == b
         res = f(Arb(a))
         abs_value && Arblib.abs!(res, res)
-        return res
+        abs_value && Arblib.nonnegative_part!(res, res)
+        if logging isa Val{true}
+            push!(logger.intervals, (a, b))
+            push!(logger.data, res)
+            return res, logger
+        else
+            return res
+        end
     end
 
     ubound_tol = convert(Arb, ubound_tol)
@@ -569,7 +670,7 @@ function maximum_enclosure(
         values_low = similar(values, Arf)
         values_upp = similar(values, Arf)
         for i in eachindex(values)
-            values_low[i], values_upp[i] = getinterval(Arf, values[i])
+            values_low[i], values_upp[i] = getinterval(values[i])
         end
 
         # Compute current lower and upper bound of maximum
@@ -603,10 +704,18 @@ function maximum_enclosure(
                 end
             end
         end
-        intervals = bisect_intervals(intervals, to_split, log_midpoint = log_bisection)
+
+        if logging isa Val{true}
+            for i in eachindex(intervals)
+                if !to_split[i]
+                    push!(logger.intervals, intervals[i])
+                    push!(logger.data, values[i])
+                end
+            end
+        end
 
         verbose && @info "iteration: $(lpad(iterations, 2)), " *
-              "remaining intervals: $(lpad(length(intervals) ÷ 2, 3)), " *
+              "remaining intervals: $(lpad(sum(to_split) ÷ 2, 3)), " *
               "maximum: $(format_interval(max_current_low, max_current_upp))"
 
         if verbose
@@ -614,7 +723,7 @@ function maximum_enclosure(
             non_finite > 0 && @info "non-finite intervals: $non_finite"
         end
 
-        isempty(intervals) && break
+        any(to_split) || break
 
         # Check if we have done the maximum number of function
         # evaluations or reached the maximum depth
@@ -624,12 +733,30 @@ function maximum_enclosure(
                     @info "reached maximum number of evaluations $evals >= $maxevals"
                 iterations >= depth - depth_start && @info "reached maximum depth $depth"
             end
+
+            if logging isa Val{true}
+                # Log intervals that were not included above
+                for i in eachindex(intervals)
+                    if to_split[i]
+                        push!(logger.intervals, intervals[i])
+                        push!(logger.data, values[i])
+                    end
+                end
+            end
+
             max_low, max_upp = max_current_low, max_current_upp
             break
         end
+
+        intervals = bisect_intervals(intervals, to_split, log_midpoint = log_bisection)
     end
 
     res = Arb((max_low, max_upp))
     abs_value && Arblib.nonnegative_part!(res, res)
-    return res
+    if logging isa Val{true}
+        sort_logger!(logger)
+        return res, logger
+    else
+        return res
+    end
 end

--- a/test/extrema_enclosure.jl
+++ b/test/extrema_enclosure.jl
@@ -215,4 +215,57 @@
             verbose = true,
         )
     end
+
+    @testset "logging" begin
+        a = Arf(0)
+        b = Arf(1)
+        min1, max1, logger1 =
+            ArbExtras.extrema_enclosure(identity, a, b, degree = -1, logging = Val(true))
+        min2, logger2 =
+            ArbExtras.minimum_enclosure(identity, a, b, degree = -1, logging = Val(true))
+        max3, logger3 =
+            ArbExtras.maximum_enclosure(identity, a, b, degree = -1, logging = Val(true))
+
+
+        # Check that endpoints are sorted
+        @test issorted(getindex.(logger1.intervals, 1))
+        @test issorted(getindex.(logger1.intervals, 2))
+        @test issorted(getindex.(logger2.intervals, 1))
+        @test issorted(getindex.(logger2.intervals, 2))
+        @test issorted(getindex.(logger3.intervals, 1))
+        @test issorted(getindex.(logger3.intervals, 2))
+
+        # Check that all intervals are valid intervals
+        @test all(((a, b),) -> ArbExtras.check_interval(Bool, a, b), logger1.intervals)
+        @test all(((a, b),) -> ArbExtras.check_interval(Bool, a, b), logger2.intervals)
+        @test all(((a, b),) -> ArbExtras.check_interval(Bool, a, b), logger3.intervals)
+
+        # Check that first and last agree with endpoints
+        @test logger1.intervals[1][1] == a
+        @test logger1.intervals[end][2] == b
+        @test logger2.intervals[1][1] == a
+        @test logger2.intervals[end][2] == b
+        @test logger3.intervals[1][1] == a
+        @test logger3.intervals[end][2] == b
+
+        # Check that intervals have overlapping endpoints
+        @test getindex.(logger1.intervals, 2)[1:(end-1)] ==
+              getindex.(logger1.intervals, 1)[2:end]
+        @test getindex.(logger2.intervals, 2)[1:(end-1)] ==
+              getindex.(logger2.intervals, 1)[2:end]
+        @test getindex.(logger3.intervals, 2)[1:(end-1)] ==
+              getindex.(logger3.intervals, 1)[2:end]
+
+        # Check that bounds are not smaller/larger than final enclosure
+        @test all(!, min1 .> getindex.(logger1.data, 1))
+        @test all(!, max1 .< getindex.(logger1.data, 2))
+        @test all(!, min2 .> logger2.data)
+        @test all(!, max3 .< logger3.data)
+
+        # Check that bounds enclose final enclosure
+        @test Arblib.overlaps(min1, minimum(getindex.(logger1.data, 1)))
+        @test Arblib.overlaps(max1, maximum(getindex.(logger1.data, 2)))
+        @test Arblib.overlaps(min2, minimum(logger2.data))
+        @test Arblib.overlaps(max3, maximum(logger3.data))
+    end
 end


### PR DESCRIPTION
This adds support for returning a detailed log of the computations for `extrema_enclosure`, `maximum_enclosure` and `minimum_enclosure`. This is enabled by giving the argument `logging = Val(true)`.

The logging is returned as a new struct `BisectionLogging{T}`. It contains a list of all the final subintervals and enclosures of the extrema for each of them. The struct is written to potentially allow support for adding logging to other type of adaptive bisection algorithms in the future. 