### PR TITLE
`fx_div_x`: New function for enclosing removable singularities

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ things:
   derivative of `f`, which is computed using `ArbSeries`. So it can be
   of use if there is no implementation of `f(::Acb)`, but there is one
   for `f(::ArbSeries)`.
+- `fx_div_x(f, x, order)` can be used to compute enclosures of `f(x) /
+  x^order` when this has a removable singularity at zero.
 - `SpecialFunctions.besselj(ν::Arb, z::ArbSeries)` and
   `SpecialFunctions.bessely(ν::Arb, z::ArbSeries)` for computing
   Taylor expansions of the Bessel functions.

--- a/src/ArbExtras.jl
+++ b/src/ArbExtras.jl
@@ -21,6 +21,8 @@ include("special_functions.jl")
 
 include("integrate.jl")
 
+include("fx_div_x.jl")
+
 # Mark primary functions as public (only supported for Julia v1.11 and later)
 
 # Enclosing roots
@@ -53,5 +55,7 @@ include("integrate.jl")
 # temporary.jl
 @public iscpx
 @public compose_zero, compose_zero!
+# fx_div_x.jl
+@public fx_div_x
 
 end # module

--- a/src/fx_div_x.jl
+++ b/src/fx_div_x.jl
@@ -1,0 +1,189 @@
+"""
+    _taylor_with_lagrange_remainder(f, x0::T, interval::T; degree::Integer, enclosure_degree = 0) where {T<:Union{Arb,Acb}}
+
+Compute the Taylor expansion of `f` at the point `x0` of degree
+`degree` with the last term being the remainder term in Lagrange form,
+which ensures that the truncated version gives an enclosure of `f(x)`
+for all `x ∈ interval`.
+
+We require that `x0 ∈ interval`.
+
+For wide values of `interval`, it computes a tighter enclosure of the
+remainder term using [`ArbExtras.enclosure_series`](@ref). The degree
+used for this can be set with `enclosure_degree`. Setting it to a
+negative number computes the remainder directly instead. For `Acb`,
+`enclosure_degree` is accepted but has no effect; the remainder term
+is always computed directly.
+"""
+function _taylor_with_lagrange_remainder(
+    f,
+    x0::T,
+    interval::T;
+    degree::Integer,
+    enclosure_degree::Integer = 0,
+) where {T<:Union{Arb,Acb}}
+    Arblib.contains(interval, x0) || throw(
+        ArgumentError(
+            "expected x0 to be contained in interval, got x0 = $x0, interval = $interval",
+        ),
+    )
+
+    TSeries = T == Arb ? ArbSeries : AcbSeries
+
+    if x0 == interval
+        # In this case, we can compute the full expansion directly
+        return f(TSeries((x0, 1); degree))
+    end
+
+    # Compute the expansion without the remainder term
+    res = f(TSeries((x0, 1), degree = degree - 1))
+
+    # Make room for the remainder term
+    res = TSeries(res; degree)
+
+    # Compute the remainder term
+    if T == Arb && enclosure_degree >= 0
+        # We compute a tighter enclosure with the help of enclosure_series
+        res[degree] =
+            enclosure_series(
+                derivative_function(f, degree),
+                interval,
+                degree = enclosure_degree,
+            ) / factorial(degree)
+    else
+        res[degree] = f(TSeries((interval, 1); degree))[degree]
+    end
+
+    return res
+end
+
+"""
+    fx_div_x(f, x::Union{Arb,Acb}, order::Integer = 1; extra_degree = 0, enclosure_degree = 0, force = false)
+    fx_div_x(f, x::Union{ArbSeries,AcbSeries}, order::Integer = 1; extra_degree = 0, enclosure_degree = 0, force = false)
+
+Compute an enclosure of `f(x) / x^order` for a function `f` with a
+zero of the given order at the origin. This can be used to compute
+enclosures for functions with removable singularities.
+
+Setting `extra_degree` to a value higher than `0` makes it use a
+higher order expansion to enclose the value. This can give tighter
+bounds in many cases. The argument `enclosure_degree` is passed to
+[`_taylor_with_lagrange_remainder`](@ref).
+
+If `force = false`, it requires that the enclosure of `f` at zero is
+exactly zero. If `f` is known to be exactly zero at zero but the
+enclosure might be wider, it can be forced to be zero by setting `force
+= true`.
+
+This function is based on Lemma A.1 in Appendix A of
+
+> Dahne, J., & Gómez-Serrano, J. (2023). Highest Cusped Waves for the
+> Burgers–Hilbert Equation. *Archive for Rational Mechanics and
+> Analysis*, 247(5). https://doi.org/10.1007/s00205-023-01904-6
+"""
+function fx_div_x(
+    f,
+    x::Union{Arb,Acb},
+    order::Integer = 1;
+    extra_degree::Integer = 0,
+    enclosure_degree::Integer = 0,
+    force::Bool = false,
+)
+    Arblib.contains_zero(x) || throw(ArgumentError("x must contain zero, got x = $x"))
+    order >= 1 || throw(ArgumentError("order must be at least 1, got $order"))
+    extra_degree >= 0 ||
+        throw(ArgumentError("extra_degree must be non-negative, got $extra_degree"))
+
+    if iszero(x)
+        # If x is exactly zero, there is no need to compute extra terms
+        # in the expansion
+        extra_degree = 0
+    end
+
+    expansion = _taylor_with_lagrange_remainder(
+        f,
+        zero(x),
+        x,
+        degree = order + extra_degree;
+        enclosure_degree,
+    )
+
+    isfinite(expansion) || return Arblib.indeterminate!(zero(x))
+
+    if force
+        for i = 0:(order-1)
+            Arblib.contains_zero(Arblib.ref(expansion, i)) || error(
+                "coefficient $i of the expansion does not contain zero, got $(expansion[i])",
+            )
+            expansion[i] = 0
+        end
+    end
+
+    return Arblib.shift_right!(
+        typeof(expansion)(
+            degree = Arblib.degree(expansion) - order,
+            prec = precision(expansion),
+        ),
+        expansion,
+        order,
+    )(
+        x,
+    )
+end
+
+function fx_div_x(
+    f,
+    x::T,
+    order::Integer = 1;
+    extra_degree::Integer = 0,
+    enclosure_degree::Integer = 0,
+    force::Bool = false,
+) where {T<:Union{ArbSeries,AcbSeries}}
+    x0 = x[0]
+    Arblib.contains_zero(x0) ||
+        throw(ArgumentError("x[0] must contain zero, got x[0] = $x0"))
+    order >= 1 || throw(ArgumentError("order must be at least 1, got $order"))
+    extra_degree >= 0 ||
+        throw(ArgumentError("extra_degree must be non-negative, got $extra_degree"))
+
+    expansion = _taylor_with_lagrange_remainder(
+        f,
+        zero(x0),
+        x0,
+        degree = Arblib.degree(x) + order + extra_degree;
+        enclosure_degree,
+    )
+
+    if !isfinite(expansion)
+        indeterminate_res = zero(x)
+        ind_Arb = Arblib.indeterminate!(zero(x0))
+        for i = 0:Arblib.degree(x)
+            indeterminate_res[i] = ind_Arb
+        end
+        return indeterminate_res
+    end
+
+    if force
+        for i = 0:(order-1)
+            Arblib.contains_zero(Arblib.ref(expansion, i)) || error(
+                "coefficient $i of the expansion does not contain zero, got $(expansion[i])",
+            )
+            expansion[i] = 0
+        end
+    end
+
+    expansion_div_x = Arblib.shift_right!(
+        T(degree = Arblib.degree(expansion) - order, prec = precision(expansion)),
+        expansion,
+        order,
+    )
+
+    # Set the result to the Taylor series of f(x) / x^order at x0
+    res = T(degree = Arblib.degree(x))
+    for i = 0:Arblib.degree(res)
+        res[i] = expansion_div_x(x0) / factorial(i)
+        Arblib.derivative!(expansion_div_x, expansion_div_x)
+    end
+
+    return compose_zero(res, x)
+end

--- a/test/fx_div_x.jl
+++ b/test/fx_div_x.jl
@@ -1,0 +1,263 @@
+@testset "fx_div_x" begin
+    fs = [sin, tan, x -> x^2, x -> exp(x) - 1, x -> sin(x) - x, x -> sin(x + π)]
+    orders = [1, 1, 1, 1, 2, 1]
+    forces = [false, false, false, false, false, true]
+
+    @testset "x::Arb" begin
+        for (f, order, force) in zip(fs, orders, forces)
+            for radius in Arb(2) .^ (-10:1)
+                x = Arblib.add_error!(zero(Arb), radius)
+                if isfinite(f(ArbSeries((x, 1)))) # No point to test otherwise
+                    enclosures = [
+                        ArbExtras.fx_div_x(
+                            f,
+                            x,
+                            order;
+                            extra_degree,
+                            enclosure_degree,
+                            force,
+                        ) for extra_degree = 0:2, enclosure_degree = -1:2
+                    ]
+                    @test all(isfinite, enclosures)
+                    for y in range(getinterval(Arb, x)..., 10)
+                        exact = f(y) / y^order
+                        @test all(Arblib.overlaps.(enclosures, Ref(exact)))
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "x::Acb" begin
+        for (f, order, force) in zip(fs, orders, forces)
+            for radius in Arb(2) .^ (-10:1)
+                x = Arblib.add_error!(zero(Acb), radius)
+                if isfinite(f(AcbSeries((x, 1)))) # No point to test otherwise
+                    enclosures = [
+                        ArbExtras.fx_div_x(
+                            f,
+                            x,
+                            order;
+                            extra_degree,
+                            enclosure_degree,
+                            force,
+                        ) for extra_degree = 0:2, enclosure_degree = -1:2
+                    ]
+                    @test all(isfinite, enclosures)
+                    y_reals = range(getinterval(Arb, real(x))..., 10)
+                    y_imags = range(getinterval(Arb, imag(x))..., 10)
+                    for y_real in y_reals
+                        y1 = Acb(y_real, y_imags[1])
+                        y2 = Acb(y_real, y_imags[end])
+                        @test all(Arblib.overlaps.(enclosures, Ref(f(y1) / y1^order)))
+                        @test all(Arblib.overlaps.(enclosures, Ref(f(y2) / y2^order)))
+                    end
+                    for y_imag in y_imags
+                        y1 = Acb(y_reals[1], y_imag)
+                        y2 = Acb(y_reals[end], y_imag)
+                        @test all(Arblib.overlaps.(enclosures, Ref(f(y1) / y1^order)))
+                        @test all(Arblib.overlaps.(enclosures, Ref(f(y2) / y2^order)))
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "x::ArbSeries" begin
+        # Pure derivative
+        for (f, order, force) in zip(fs, orders, forces)
+            for radius in Arb(2) .^ (-10:1)
+                for degree = 0:4
+                    x = ArbSeries((Arblib.add_error!(zero(Arb), radius), 1); degree)
+                    if isfinite(f(ArbSeries((x[0], 1)))) # No point to test otherwise
+                        enclosures = [
+                            ArbExtras.fx_div_x(
+                                f,
+                                x,
+                                order;
+                                extra_degree,
+                                enclosure_degree,
+                                force,
+                            ) for extra_degree = 0:2, enclosure_degree = -1:2
+                        ]
+                        @test all(isfinite, enclosures)
+                        for y in range(getinterval(Arb, x[0])..., 10)
+                            y_s = ArbSeries(x)
+                            y_s[0] = y
+                            exact = f(y_s) / y_s^order
+                            @test all(Arblib.overlaps.(enclosures, Ref(exact)))
+                        end
+                    end
+                end
+            end
+        end
+
+        # General series
+        for (f, order, force) in zip(fs, orders, forces)
+            for radius in Arb(2) .^ (-10:1)
+                for degree = 0:4
+                    x = ArbSeries((Arblib.add_error!(zero(Arb), radius), 2, 3); degree)
+                    if isfinite(f(ArbSeries((x[0], 1)))) # No point to test otherwise
+                        enclosures = [
+                            ArbExtras.fx_div_x(
+                                f,
+                                x,
+                                order;
+                                extra_degree,
+                                enclosure_degree,
+                                force,
+                            ) for extra_degree = 0:2, enclosure_degree = -1:2
+                        ]
+                        @test all(isfinite, enclosures)
+                        for y in range(getinterval(Arb, x[0])..., 10)
+                            y_s = ArbSeries(x)
+                            y_s[0] = y
+                            exact = f(y_s) / y_s^order
+                            @test all(Arblib.overlaps.(enclosures, Ref(exact)))
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "x::AcbSeries" begin
+        # Pure derivative
+        for (f, order, force) in zip(fs, orders, forces)
+            for radius in Arb(2) .^ (-10:1)
+                for degree = 0:4
+                    x = AcbSeries((Arblib.add_error!(zero(Acb), radius), 1); degree)
+                    if isfinite(f(AcbSeries((x[0], 1)))) # No point to test otherwise
+                        enclosures = [
+                            ArbExtras.fx_div_x(
+                                f,
+                                x,
+                                order;
+                                extra_degree,
+                                enclosure_degree,
+                                force,
+                            ) for extra_degree = 0:2, enclosure_degree = -1:2
+                        ]
+                        @test all(isfinite, enclosures)
+                        y_reals = range(getinterval(Arb, real(x[0]))..., 10)
+                        y_imags = range(getinterval(Arb, imag(x[0]))..., 10)
+                        for y_real in y_reals
+                            y1 = AcbSeries(x);
+                            y1[0] = Acb(y_real, y_imags[1])
+                            y2 = AcbSeries(x);
+                            y2[0] = Acb(y_real, y_imags[end])
+                            @test all(Arblib.overlaps.(enclosures, Ref(f(y1) / y1^order)))
+                            @test all(Arblib.overlaps.(enclosures, Ref(f(y2) / y2^order)))
+                        end
+                        for y_imag in y_imags
+                            y1 = AcbSeries(x);
+                            y1[0] = Acb(y_reals[1], y_imag)
+                            y2 = AcbSeries(x);
+                            y2[0] = Acb(y_reals[end], y_imag)
+                            @test all(Arblib.overlaps.(enclosures, Ref(f(y1) / y1^order)))
+                            @test all(Arblib.overlaps.(enclosures, Ref(f(y2) / y2^order)))
+                        end
+                    end
+                end
+            end
+        end
+
+        # General series
+        for (f, order, force) in zip(fs, orders, forces)
+            for radius in Arb(2) .^ (-10:1)
+                for degree = 0:4
+                    x = AcbSeries((Arblib.add_error!(zero(Acb), radius), 2, 3); degree)
+                    if isfinite(f(AcbSeries((x[0], 1)))) # No point to test otherwise
+                        enclosures = [
+                            ArbExtras.fx_div_x(
+                                f,
+                                x,
+                                order;
+                                extra_degree,
+                                enclosure_degree,
+                                force,
+                            ) for extra_degree = 0:2, enclosure_degree = -1:2
+                        ]
+                        @test all(isfinite, enclosures)
+                        y_reals = range(getinterval(Arb, real(x[0]))..., 10)
+                        y_imags = range(getinterval(Arb, imag(x[0]))..., 10)
+                        for y_real in y_reals
+                            y1 = AcbSeries(x);
+                            y1[0] = Acb(y_real, y_imags[1])
+                            y2 = AcbSeries(x);
+                            y2[0] = Acb(y_real, y_imags[end])
+                            @test all(Arblib.overlaps.(enclosures, Ref(f(y1) / y1^order)))
+                            @test all(Arblib.overlaps.(enclosures, Ref(f(y2) / y2^order)))
+                        end
+                        for y_imag in y_imags
+                            y1 = AcbSeries(x);
+                            y1[0] = Acb(y_reals[1], y_imag)
+                            y2 = AcbSeries(x);
+                            y2[0] = Acb(y_reals[end], y_imag)
+                            @test all(Arblib.overlaps.(enclosures, Ref(f(y1) / y1^order)))
+                            @test all(Arblib.overlaps.(enclosures, Ref(f(y2) / y2^order)))
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "Non-finite" begin
+        x_Arb = Arblib.add_error!(zero(Arb), Arb(1))
+        x_Acb = Arblib.add_error!(zero(Acb), Arb(1))
+        x_ArbSeries = ArbSeries((Arblib.add_error!(zero(Arb), Arb(1)), 1))
+        x_AcbSeries = AcbSeries((Arblib.add_error!(zero(Acb), Arb(1)), 1))
+
+        @test !isfinite(ArbExtras.fx_div_x(x -> 1 / x, x_Arb))
+        @test !isfinite(ArbExtras.fx_div_x(x -> 1 / x, x_Acb))
+        @test !isfinite(ArbExtras.fx_div_x(x -> 1 / x, x_ArbSeries))
+        @test !isfinite(ArbExtras.fx_div_x(x -> 1 / x, x_AcbSeries))
+    end
+
+    @testset "Zero" begin
+        # sin(x) / x → 1 as x → 0
+        @test Arblib.overlaps(ArbExtras.fx_div_x(sin, zero(Arb)), Arb(1))
+        @test Arblib.overlaps(ArbExtras.fx_div_x(sin, zero(Acb)), Acb(1))
+        # sin(x) / x at x = 0 + 1*t gives the series [1, 0]: constant term 1, linear term 0
+        @test Arblib.overlaps(
+            ArbExtras.fx_div_x(sin, ArbSeries((zero(Arb), 1))),
+            ArbSeries((1, 0)),
+        )
+        @test Arblib.overlaps(
+            ArbExtras.fx_div_x(sin, AcbSeries((zero(Acb), 1))),
+            AcbSeries((1, 0)),
+        )
+    end
+
+    @testset "Throws" begin
+        x_Arb = Arblib.add_error!(zero(Arb), Arb(1))
+        x_Acb = Arblib.add_error!(zero(Acb), Arb(1))
+        x_ArbSeries = ArbSeries((Arblib.add_error!(zero(Arb), Arb(1)), 1))
+        x_AcbSeries = AcbSeries((Arblib.add_error!(zero(Acb), Arb(1)), 1))
+
+        # x does not contain zero
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, Arb(1))
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, Acb(1))
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, ArbSeries((Arb(1), 1)))
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, AcbSeries((Acb(1), 1)))
+
+        # order < 1
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, x_Arb, 0)
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, x_Acb, 0)
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, x_ArbSeries, 0)
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, x_AcbSeries, 0)
+
+        # extra_degree < 0
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, x_Arb; extra_degree = -1)
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, x_Acb; extra_degree = -1)
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, x_ArbSeries; extra_degree = -1)
+        @test_throws ArgumentError ArbExtras.fx_div_x(sin, x_AcbSeries; extra_degree = -1)
+
+        # force = true but f does not have a zero at 0
+        @test_throws ErrorException ArbExtras.fx_div_x(cos, x_Arb; force = true)
+        @test_throws ErrorException ArbExtras.fx_div_x(cos, x_Acb; force = true)
+        @test_throws ErrorException ArbExtras.fx_div_x(cos, x_ArbSeries; force = true)
+        @test_throws ErrorException ArbExtras.fx_div_x(cos, x_AcbSeries; force = true)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,4 +18,6 @@ include("demo_problems.jl")
     include("special_functions.jl")
 
     include("integrate.jl")
+
+    include("fx_div_x.jl")
 end


### PR DESCRIPTION
I have used this in multiple different projects by now. So it is probably about time to add it here (together with more thorough tests).