### PR TITLE
Drop support for Julia version before 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,27 +9,36 @@ on:
       - master
 
 jobs:
-  test-julia-stable:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        julia-version: ['1.6', '1', 'nightly']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
       fail-fast: false
-
+      matrix:
+        version:
+          - '1.10'
+          - '1'
+          - 'nightly'
+        os:
+          - 'ubuntu-latest'
+          - 'macOS-latest'
+          - 'windows-latest'
+        arch:
+          - x64
     steps:
-      - uses: actions/checkout@v1.0.0
-      - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: ./lcov.info
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: false
-          comment: false
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ PropCheck = "0.10"
 Random = "1.6"
 SpecialFunctions = "1, 2"
 Test = "1.6"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 PropCheck = "ca382230-33be-11e9-0059-d981d03070e4"


### PR DESCRIPTION
This is the same limit as Arblib sets, so should cause any issues.