### PR TITLE
Do not define besselj for Arblib v1.8.0 or later

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArbExtras"
 uuid = "c87f5d39-a852-4149-8a88-e3a13a25afc6"
 authors = ["Joel Dahne <joel@dahne.eu>"]
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 Arblib = "fb37089c-8514-4489-9461-98f9c8763369"

--- a/src/special_functions.jl
+++ b/src/special_functions.jl
@@ -125,12 +125,16 @@ function _besseljy(
     return compose_zero!(res, res, z)
 end
 
-SpecialFunctions.besselj(ν::Arblib.ArbOrRef, z::Arblib.ArbSeries) =
-    _besseljy(Arblib.hypgeom_bessel_j!, ν, z)
+# Arblib 1.8.0 includes support for series expansion of besselj, so we
+# no longer want to overwrite it.
+if pkgversion(Arblib) < v"1.8.0"
+    SpecialFunctions.besselj(ν::Arblib.ArbOrRef, z::Arblib.ArbSeries) =
+        _besseljy(Arblib.hypgeom_bessel_j!, ν, z)
+    SpecialFunctions.besselj0(z::ArbSeries) = besselj(zero(Arb), z)
+    SpecialFunctions.besselj1(z::ArbSeries) = besselj(one(Arb), z)
+end
+
 SpecialFunctions.bessely(ν::Arblib.ArbOrRef, z::Arblib.ArbSeries) =
     _besseljy(Arblib.hypgeom_bessel_y!, ν, z)
-
-SpecialFunctions.besselj0(z::ArbSeries) = besselj(zero(Arb), z)
-SpecialFunctions.besselj1(z::ArbSeries) = besselj(one(Arb), z)
 SpecialFunctions.bessely0(z::ArbSeries) = bessely(zero(Arb), z)
 SpecialFunctions.bessely1(z::ArbSeries) = bessely(one(Arb), z)


### PR DESCRIPTION
It was added to Arblib at this version. Having to fix this is one of the issues with type piracy...